### PR TITLE
fix: move from markdown to html

### DIFF
--- a/data/acronyms.json
+++ b/data/acronyms.json
@@ -9,37 +9,37 @@
         "Abbreviation": "ACK",
         "Definition": "ACKnowledgement",
         "Usage": "agreed/accepted change. A loose ACK can be confusing. It's best to avoid them unless it's a documentation/comment only change in which case there is nothing to test/verify; therefore the tested/untested distinction is not there",
-        "Example": "[Humanizer](https://github.com/Humanizr/Humanizer/pull/1134#discussion_r737686977), [Bitcoin](https://github.com/bitcoin/bitcoin/issues/6100)"
+        "Example": "<a href=\"https://github.com/Humanizr/Humanizer/pull/1134#discussion_r737686977\">Humanizer</a>, <a href=\"https://github.com/bitcoin/bitcoin/issues/6100\">Bitcoin</a>"
     },
     {
         "Abbreviation": "NACK/NAK",
         "Definition": "Negative ACKnowledgement",
         "Usage": "disagree with the code changes/concept. Should be accompanied by an explanation",
-        "Example": "[Bitcoin](https://github.com/bitcoin/bitcoin/issues/6100)"
+        "Example": "<a href=\"https://github.com/bitcoin/bitcoin/issues/6100\">Bitcoin</a>"
     },
     {
         "Abbreviation": "tested ACK",
         "Definition": "Tested ACKnowledgment",
         "Usage": "reviewed the code changes and have verified the functionality or bug fix",
-        "Example": "[Bitcoin](https://github.com/bitcoin/bitcoin/issues/6100)"
+        "Example": "<a href=\"https://github.com/bitcoin/bitcoin/issues/6100\">Bitcoin</a>"
     },
     {
         "Abbreviation": "utACK",
         "Definition": "UnTested ACKnowledgment",
         "Usage": "reviewed and agree with the code changes but haven't actually tested them",
-        "Example": "[Bitcoin](https://github.com/bitcoin/bitcoin/issues/6100)"
+        "Example": "<a href=\"https://github.com/bitcoin/bitcoin/issues/6100\">Bitcoin</a>"
     },
     {
         "Abbreviation": "Concept ACK",
         "Definition": "Concept ACKnowledgement",
         "Usage": "agree with the idea and overall direction, but haven't reviewed the code changes or tested them",
-        "Example": "[Bitcoin](https://github.com/bitcoin/bitcoin/issues/6100)"
+        "Example": "<a href=\"https://github.com/bitcoin/bitcoin/issues/6100\">Bitcoin</a>"
     },
     {
         "Abbreviation": "LGTM",
         "Definition": "Looks Good To Me",
         "Usage": "see ACK",
-        "Example": "[Cardidy](https://github.com/d-edge/Cardidy/pull/57#pullrequestreview-791829899), [Simple Icons](https://github.com/simple-icons/simple-icons/pull/6762#pullrequestreview-799347702), [proposal-array-grouping](https://github.com/tc39/proposal-array-grouping/issues/3#issuecomment-883089358)"
+        "Example": "<a href=\"https://github.com/d-edge/Cardidy/pull/57#pullrequestreview-791829899\">Cardidy</a>, <a href=\"https://github.com/simple-icons/simple-icons/pull/6762#pullrequestreview-799347702\">Simple Icons</a>, <a href=\"https://github.com/tc39/proposal-array-grouping/issues/3#issuecomment-883089358\">proposal-array-grouping</a>"
     },
     {
         "Abbreviation": "RFC",
@@ -51,7 +51,7 @@
         "Abbreviation": "AFAIK",
         "Definition": "As Far As I Know",
         "Usage": "",
-        "Example": "[Diffract](https://github.com/d-edge/Diffract/issues/1#issuecomment-946781621)"
+        "Example": "<a href=\"https://github.com/d-edge/Diffract/issues/1#issuecomment-946781621\">Diffract</a>"
     },
     {
         "Abbreviation": "AFAICT",
@@ -69,7 +69,7 @@
         "Abbreviation": "IANAL",
         "Definition": "I Am Not A Lawyer",
         "Usage": "used often before talking about licensing issues",
-        "Example": "[HackerNews](https://news.ycombinator.com/item?id=29080575), [CUPS](https://github.com/OpenPrinting/cups/issues/315#issue-1088620780)"
+        "Example": "<a href=\"https://news.ycombinator.com/item?id=29080575\">HackerNews</a>, <a href=\"https://github.com/OpenPrinting/cups/issues/315#issue-1088620780\">CUPS</a>"
     },
     {
         "Abbreviation": "CMV",
@@ -111,7 +111,7 @@
         "Abbreviation": "PR",
         "Definition": "Pull Request",
         "Usage": "tell others about changes you've pushed to a branch in a repository",
-        "Example": "[/r/vuejs](https://www.reddit.com/r/vuejs/comments/qh5oeu/the_vuejs_framework_repository_summary/hic9siz/)"
+        "Example": "<a href=\"https://www.reddit.com/r/vuejs/comments/qh5oeu/the_vuejs_framework_repository_summary/hic9siz/\">/r/vuejs</a>"
     },
     {
         "Abbreviation": "MR",
@@ -123,37 +123,37 @@
         "Abbreviation": "MVP",
         "Definition": "Minimum Viable Product",
         "Usage": "a prototype version of a product with the minimum required feature set",
-        "Example": "[Wikipedia](https://en.wikipedia.org/wiki/Minimum_viable_product)"
+        "Example": "<a href=\"https://en.wikipedia.org/wiki/Minimum_viable_product\">Wikipedia</a>"
     },
     {
         "Abbreviation": "NIH",
         "Definition": "Not Invented Here",
         "Usage": "NIH Syndrome is a decision-making error where we tend to value our own ideas above those conceived by people outside of our group",
-        "Example": "[learnosity](https://learnosity.com/not-invented-here-syndrome-explained/)"
+        "Example": "<a href=\"https://learnosity.com/not-invented-here-syndrome-explained/\">learnosity</a>"
     },
     {
         "Abbreviation": "SOLID",
         "Definition": "Single responsibility, Open-closed, Liskov substitution, Interface segregation and Dependency inversion",
         "Usage": "5 (of many) software design principles, promoted by Robert \"Uncle Bob\" Martin",
-        "Example": "[wikipedia](https://en.wikipedia.org/wiki/SOLID)"
+        "Example": "<a href=\"https://en.wikipedia.org/wiki/SOLID\">wikipedia</a>"
     },
     {
         "Abbreviation": "SRP",
         "Definition": "Single-Responsibility Principle",
-        "Usage": "The single-responsibility principle is a computer-programming principle that states that every module, class or function in a computer program should have responsibility over a single part of that program's functionality, and it should encapsulate that part. [wikipedia](https://en.wikipedia.org/wiki/Single-responsibility_principle)",
-        "Example": "[/r/csharp/](https://www.reddit.com/r/csharp/comments/qv490z/using_a_tuple_to_initialize_properties_in_the/hku5pw6/)"
+        "Usage": "The single-responsibility principle is a computer-programming principle that states that every module, class or function in a computer program should have responsibility over a single part of that program's functionality, and it should encapsulate that part. <a href=\"https://en.wikipedia.org/wiki/Single-responsibility_principle\">wikipedia</a>",
+        "Example": "<a href=\"https://www.reddit.com/r/csharp/comments/qv490z/using_a_tuple_to_initialize_properties_in_the/hku5pw6/\">/r/csharp/</a>"
     },
     {
         "Abbreviation": "DRY",
         "Definition": "Don't Repeat Yourself",
         "Usage": "This is used in couple with modular programming, and emphasize on code reusability",
-        "Example": "[Wikipedia](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)"
+        "Example": "<a href=\"https://en.wikipedia.org/wiki/Don%27t_repeat_yourself\">Wikipedia</a>"
     },
     {
         "Abbreviation": "KISS",
         "Definition": "Keep It Simple, Stupid",
         "Usage": "KISS is a design principle stating that most systems work fine if it is built/kept simple than making the system complex.",
-        "Example": "[Wikipedia](https://en.wikipedia.org/wiki/KISS_principle#:~:text=KISS%2C%20an%20acronym%20for%20keep,unnecessary%20complexity%20should%20be%20avoided.)"
+        "Example": "<a href=\"https://en.wikipedia.org/wiki/KISS_principle#:~:text=KISS%2C%20an%20acronym%20for%20keep,unnecessary%20complexity%20should%20be%20avoided.\">Wikipedia</a>"
     },
     {
         "Abbreviation": "YAGNI",
@@ -165,7 +165,7 @@
         "Abbreviation": "FYI",
         "Definition": "For Your Information",
         "Usage": "",
-        "Example": "[ArduPilot](https://github.com/ArduPilot/MissionPlanner/issues/2216), [F#'s slack](https://fsharp.slack.com/archives/C1JH32U5D/p1635256259002400)"
+        "Example": "<a href=\"https://github.com/ArduPilot/MissionPlanner/issues/2216\">ArduPilot</a>, <a href=\"https://fsharp.slack.com/archives/C1JH32U5D/p1635256259002400\">F#'s slack</a>"
     },
     {
         "Abbreviation": "NP",
@@ -177,7 +177,7 @@
         "Abbreviation": "TBD",
         "Definition": "To Be Defined/Done",
         "Usage": "",
-        "Example": "[Software Craft Website](https://github.com/softwarecrafters/website/blob/0a3a1c5b303c3361dccd985cd25348fde06b84c5/README.md?plain=1#L66)"
+        "Example": "<a href=\"https://github.com/softwarecrafters/website/blob/0a3a1c5b303c3361dccd985cd25348fde06b84c5/README.md?plain=1#L66\">Software Craft Website</a>"
     },
     {
         "Abbreviation": "ICYMI",
@@ -195,13 +195,13 @@
         "Abbreviation": "LOC/SLOC",
         "Definition": "(Source) Lines Of Code",
         "Usage": "Above each file on GitHub you can find something like `50 lines (43 sloc)`. The difference is the empty lines.",
-        "Example": "[GitHub](https://github.com/d-edge/foss-acronyms/blob/main/README.md)"
+        "Example": "<a href=\"https://github.com/d-edge/foss-acronyms/blob/main/README.md\">GitHub</a>"
     },
     {
         "Abbreviation": "TIL",
         "Definition": "Today I Learned",
         "Usage": "TIL that TIL is Today I Learned",
-        "Example": "[/r/ProgrammerTIL/](https://www.reddit.com/r/ProgrammerTIL/)"
+        "Example": "<a href=\"https://www.reddit.com/r/ProgrammerTIL/\">/r/ProgrammerTIL/</a>"
     },
     {
         "Abbreviation": "OOP",
@@ -219,25 +219,25 @@
         "Abbreviation": "CLA",
         "Definition": "Contributor License Agreement",
         "Usage": "",
-        "Example": "[Play Framework](https://github.com/playframework/playframework/pull/616#issuecomment-11394747), [Microsoft](https://cla.opensource.microsoft.com/)"
+        "Example": "<a href=\"https://github.com/playframework/playframework/pull/616#issuecomment-11394747\">Play Framework</a>, <a href=\"https://cla.opensource.microsoft.com/\">Microsoft</a>"
     },
     {
         "Abbreviation": "ETA",
         "Definition": "Estimated Time of Arrival",
         "Usage": "To ask when something will be ready",
-        "Example": "[/r/fsharp](https://www.reddit.com/r/fsharp/comments/r1fw4r/is_there_any_eta_on_safe_stack_supporting_net_6/)"
+        "Example": "<a href=\"https://www.reddit.com/r/fsharp/comments/r1fw4r/is_there_any_eta_on_safe_stack_supporting_net_6/\">/r/fsharp</a>"
     },
     {
         "Abbreviation": "FOUC",
         "Definition": "Flash Of Unstyled Content",
         "Usage": "When a web page appears briefly with the browser's default styles prior to loading an external CSS stylesheet",
-        "Example": "[md-block](https://github.com/leaverou/md-block#minimizing-fouc), [Wikipedia](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)"
+        "Example": "<a href=\"https://github.com/leaverou/md-block#minimizing-fouc\">md-block</a>, <a href=\"https://en.wikipedia.org/wiki/Flash_of_unstyled_content\">Wikipedia</a>"
     },
     {
         "Abbreviation": "VCS",
         "Definition": "Version Control Software",
         "Usage": "a way to keep a track of the changes in the code so that if something goes wrong, we can make comparisons in different code versions and revert to any previous version that we want. Git, SVN or Mercurial are VCS",
-        "Example": "[/r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor/comments/r9ah39/what_about_5000/hnbdq90/0), [softwaretestinghelp.com](https://www.softwaretestinghelp.com/version-control-software/)"
+        "Example": "<a href=\"https://www.reddit.com/r/ProgrammerHumor/comments/r9ah39/what_about_5000/hnbdq90/0\">/r/ProgrammerHumor</a>, <a href=\"https://www.softwaretestinghelp.com/version-control-software/\">softwaretestinghelp.com</a>"
     },
     {
         "Abbreviation": "SCM",
@@ -249,12 +249,12 @@
         "Abbreviation": "OP",
         "Definition": "Original Post/Original Poster",
         "Usage": "Original Poster (who started a thread) or Original Post (the message that started it)",
-        "Example": "[/r/ProgrammerHumor](https://www.reddit.com/r/ProgrammerHumor/comments/r9ah39/what_about_5000/hnbdq90/), [StackExchange](https://english.stackexchange.com/questions/424366/does-op-mean-original-poster-or-original-post)"
+        "Example": "<a href=\"https://www.reddit.com/r/ProgrammerHumor/comments/r9ah39/what_about_5000/hnbdq90/\">/r/ProgrammerHumor</a>, <a href=\"https://english.stackexchange.com/questions/424366/does-op-mean-original-poster-or-original-post\">StackExchange</a>"
     },
     {
         "Abbreviation": "RTFM",
         "Definition": "Read The F*****g Manual",
         "Usage": "Originally a way for the _gurus_ to get rid of trivial questions from newbies, now a humble way to state that a mistake or a waste of time can be avoided by reading the freaking manual first (assuming it exists).",
-        "Example": "[XKCD comic](https://xkcd.com/293/), [Github commits](https://github.com/search?q=RTFM&type=Commits)"
+        "Example": "<a href=\"https://xkcd.com/293/\">XKCD comic</a>, <a href=\"https://github.com/search?q=RTFM&type=Commits\">Github commits</a>"
     }
 ]


### PR DESCRIPTION
Done with the regex `\[(.*?)\]\((.*?)\)` and the output `<a href=\"$2\">$1</a>`

A better solution would be to have a way to template the output and to have json's example entry to be a object with a `content` and a `href` though.

fix #35 