### PR TITLE
Add EFK stack

### DIFF
--- a/data/stacks.json
+++ b/data/stacks.json
@@ -1,5 +1,10 @@
 [
   {
+    "Abbreviation": "EFK",
+    "Definition": "Elasticsearch, Fluentd, and Kibana",
+    "Example": "<a href=\"https://www.digitalocean.com/community/tutorials/how-to-set-up-an-elasticsearch-fluentd-and-kibana-efk-logging-stack-on-kubernetes\">How To Set Up an Elasticsearch, Fluentd and Kibana (EFK) Logging Stack on Kubernetes</a>"
+  },
+  {
     "Abbreviation": "ELK",
     "Definition": "Elasticsearch, Logstash, and Kibana",
     "Example": "<a href=\"https://www.elastic.co/what-is/elk-stack\">What is the ELK Stack?</a>"


### PR DESCRIPTION
added EFK (Elasticsearch, Fluentd, and Kibana) stack, like a tutorial in the Digital Ocean site

## If you want to add or update an acronym

Keep in mind that the [readme.md] is generated. It is useless to edit it directly.
If you want to add or update an acronym, edit the correct file in the [data] folder
(e.g. [acronyms.json])

## Checklist before merging

- [x] The title says what this PR do
- [x] The description includes an issue ticket number if any
- [x] Only a `json` is changed if you want to add or update an acronym

[readme.md]: https://github.com/d-edge/foss-acronyms/blob/main/README.md
[data]: https://github.com/d-edge/foss-acronyms/tree/main/data
[acronyms.json]: https://github.com/d-edge/foss-acronyms/blob/main/data/acronyms.json
