### PR TITLE
Add WYSIWYG to Acronyms

### DIFF
--- a/data/acronyms.json
+++ b/data/acronyms.json
@@ -352,5 +352,11 @@
     "Definition": "Your Mileage May Vary",
     "Usage": "",
     "Example": ""
+  },
+  {
+    "Abbreviation": "WYSIWYG",
+    "Definition": "What You See Is What You Get",
+    "Usage": "It is a system in which editing software allows content to be edited in a form that resembles its appearance when printed or displayed as a finished product. It is typically used an arbitrary markup language to define the codes/tags",
+    "Example": "<a href=\"https://en.wikipedia.org/wiki/WYSIWYG">WYSIWYG</a>"
   }
 ]

--- a/data/acronyms.json
+++ b/data/acronyms.json
@@ -357,6 +357,6 @@
     "Abbreviation": "WYSIWYG",
     "Definition": "What You See Is What You Get",
     "Usage": "It is a system in which editing software allows content to be edited in a form that resembles its appearance when printed or displayed as a finished product. It is typically used an arbitrary markup language to define the codes/tags",
-    "Example": "<a href=\"https://en.wikipedia.org/wiki/WYSIWYG">WYSIWYG</a>"
+    "Example": "<a href=\"https://en.wikipedia.org/wiki/WYSIWYG\">WYSIWYG</a>"
   }
 ]


### PR DESCRIPTION
Added acronym for WYSIWYG which is "What You See Is What You Get". 
Editors with this functionality can display the markdown or HTML as a rendered page as you edit it.