### PR TITLE
Delete Extra double quotes

### DIFF
--- a/data/stacks.json
+++ b/data/stacks.json
@@ -12,7 +12,7 @@
   {
     "Abbreviation": "LAMP",
     "Definition": "Linux, Apache, MySQL, PHP (Perl or Python)",
-    "Example": "<a href=\"https://www.ibm.com/cloud/learn/lamp-stack-explained\">IBM Cloud</a>, <a href=\"https://en.wikipedia.org/wiki/LAMP_(software_bundle)\">Wikipedia</a>""
+    "Example": "<a href=\"https://www.ibm.com/cloud/learn/lamp-stack-explained\">IBM Cloud</a>, <a href=\"https://en.wikipedia.org/wiki/LAMP_(software_bundle)\">Wikipedia</a>"
   },
   {
     "Abbreviation": "LEMP",


### PR DESCRIPTION
Delete Extra double quotes as it causes a syntax error

## If you want to add or update an acronym

Keep in mind that the [readme.md] is generated. It is useless to edit it directly.
If you want to add or update an acronym, edit the correct file in the [data] folder
(e.g. [acronyms.json])

## Checklist before merging

- [x] The title says what this PR do
- [x] The description includes an issue ticket number if any
- [x] Only a `json` is changed if you want to add or update an acronym

[readme.md]: https://github.com/d-edge/foss-acronyms/blob/main/README.md
[data]: https://github.com/d-edge/foss-acronyms/tree/main/data
[acronyms.json]: https://github.com/d-edge/foss-acronyms/blob/main/data/acronyms.json
