### PR TITLE
Fix wrong link title

### DIFF
--- a/data/acronyms.json
+++ b/data/acronyms.json
@@ -213,7 +213,7 @@
     "Abbreviation": "MVC",
     "Definition": "Model View Controller",
     "Usage": "A commonly used software design architecture based around the Model (data), the View (user interface), and the Controller (logic to handle requests).",
-    "Example": "<a href=\"https://niroshanratnayake.medium.com/mvc-architecture-simply-explained-124729732c67\">FreeCodeCamp</a>"
+    "Example": "<a href=\"https://niroshanratnayake.medium.com/mvc-architecture-simply-explained-124729732c67\">Medium</a>"
   },
   {
     "Abbreviation": "MVP",


### PR DESCRIPTION
In #92 I changed the link to a Medium article instead of FreeCodeCamp that I believe explained MVC better, but forgot to update the link text. This PR updates the link title to be correct.

## Checklist before merging

- [x] The title says what this PR do
- [x] The description includes an issue ticket number if any
- [x] Only a `json` is changed if you want to add or update an acronym

[readme.md]: https://github.com/d-edge/foss-acronyms/blob/main/README.md
[data]: https://github.com/d-edge/foss-acronyms/tree/main/data
[acronyms.json]: https://github.com/d-edge/foss-acronyms/blob/main/data/acronyms.json
