### PR TITLE
Fix PEBCAK definition add added it's variants.

### DIFF
--- a/data/acronyms.json
+++ b/data/acronyms.json
@@ -101,6 +101,12 @@
     "Usage": "Guidelines to make onboarding and development of a project easy to get into and maintain",
     "Example": "<a href=\"https://github.com/near/near-explorer/issues/803\">Near (Github)</a>"
   },
+   {
+    "Abbreviation": "EBKAC",
+    "Definition": "Error Between Keyboard And Chair",
+    "Usage": "It's an error made by the human user of a complex system, usually a computer system, in interacting with it.",
+    "Example": "<a href=\"https://en.wikipedia.org/wiki/User_error#PEBKAC/PEBCAK/PICNIC\">User error</a>"
+  },
   {
     "Abbreviation": "ETA",
     "Definition": "Estimated Time of Arrival",
@@ -271,9 +277,39 @@
   },
   {
     "Abbreviation": "PEBCAK",
-    "Definition": "Problem Exists Between Keyboard and Chair",
+    "Definition": "Problem Exists Between Chair And Keyboard",
     "Usage": "It is a user error, not a problem / bug in the program",
     "Example": "<a href=\"https://github.com/Humanizr/Humanizer/issues/1157#issue-1086741428\">Humanizer</a>, <a href=\"https://github.com/orgs/community/discussions/25165#discussioncomment-3246690\">Community</a>"
+  },
+  {
+    "Abbreviation": "PEBKAC",
+    "Definition": "Problem Exists Between Keyboard And Chair",
+    "Usage": "It is a user error, not a problem / bug in the program",
+    "Example": "<a href=\"https://github.com/Humanizr/Humanizer/issues/1157#issue-1086741428\">Humanizer</a>, <a href=\"https://github.com/orgs/community/discussions/25165#discussioncomment-3246690\">Community</a>"
+  },
+  {
+    "Abbreviation": "PEBMAC",
+    "Definition": "Problem Exists Between Monitor And Chair",
+    "Usage": "It's an error made by the human user of a complex system, usually a computer system, in interacting with it.",
+    "Example": "<a href=\"https://en.wikipedia.org/wiki/User_error#PEBKAC/PEBCAK/PICNIC\">User error</a>"
+  },
+  {
+    "Abbreviation": "PEBUAK",
+    "Definition": "Problem Exists Between User and Keyboard",
+    "Usage": "It's an error made by the human user of a complex system, usually a computer system, in interacting with it.",
+    "Example": "<a href=\"https://en.wikipedia.org/wiki/User_error#PEBKAC/PEBCAK/PICNIC\">User error</a>"
+  },
+  {
+    "Abbreviation": "PICNIC",
+    "Definition": "Problem In Chair Not In Computer",
+    "Usage": "It's an error made by the human user of a complex system, usually a computer system, in interacting with it.",
+    "Example": "<a href=\"https://en.wikipedia.org/wiki/User_error#PEBKAC/PEBCAK/PICNIC\">User error</a>"
+  },
+  {
+    "Abbreviation": "POBCAK",
+    "Definition": "a US government/military acronym for Problem Occurs Between Chair And Keyboard",
+    "Usage": "It's an error made by the human user of a complex system, usually a computer system, in interacting with it.",
+    "Example": "<a href=\"https://en.wikipedia.org/wiki/User_error#PEBKAC/PEBCAK/PICNIC\">User error</a>, <a href=\"https://en.wikipedia.org/wiki/List_of_U.S._government_and_military_acronyms#P\">List of U.S. government and military acronyms</a>"
   },
   {
     "Abbreviation": "PR",


### PR DESCRIPTION
Added EBKAC, PEBKAC, PEBMAC, PEBUAK, PICNIC, and POBCAK. Which is have the same meaning for discovery purposes. Fix issue #106.

## If you want to add or update an acronym

Keep in mind that the [readme.md] is generated. It is useless to edit it directly.
If you want to add or update an acronym, edit the correct file in the [data] folder
(e.g. [acronyms.json])

## Checklist before merging

- [x] The title says what this PR do
- [x] The description includes an issue ticket number if any
- [x] Only a `json` is changed if you want to add or update an acronym

[readme.md]: https://github.com/d-edge/foss-acronyms/blob/main/README.md
[data]: https://github.com/d-edge/foss-acronyms/tree/main/data
[acronyms.json]: https://github.com/d-edge/foss-acronyms/blob/main/data/acronyms.json
