### PR TITLE
Fix organizations.json json syntax

### DIFF
--- a/data/organizations.json
+++ b/data/organizations.json
@@ -46,5 +46,5 @@
     "Meaning": "YouTube",
     "URL": "https://www.youtube.com/",
     "What they do": "YouTube is online video sharing and social media platform"
-  },
+  }
 ]


### PR DESCRIPTION
In JSON standard, a trailing comma after the last element in an array/object is not allowed.

fix pr #112 

## Checklist before merging

- [x] The title says what this PR do
- [x] The description includes an issue ticket number if any
- [x] Only a `json` is changed if you want to add or update an acronym